### PR TITLE
add requirements.txt from main Bismuth repo for python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-pillow
-pyqrcode
-pypng
 pyinstaller
 bottle
 pycryptodome
-simple-crypt
+simple-crypt --no-deps
 PySocks
 requests
+connections (from Bismuth)
+picklemagic (from Bismuth)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pillow
+pyqrcode
+pypng
+pyinstaller
+bottle
+pycryptodome
+simple-crypt
+PySocks
+requests


### PR DESCRIPTION
Since Optihash can be run independent of the full Bismuth install, it only makes sense to include a requirements.txt in order to install the needed python dependencies for the miner to work, as you can't assume the environment already has installed the needed libraries. 

These are taken from from https://github.com/hclivess/Bismuth/blob/master/requirements.txt, but perhaps only Pysocks is needed to get Optihash running. If so, I can revise the request. 